### PR TITLE
Fixed bug that could cause track length to be written incorrectly

### DIFF
--- a/mus2midi.c
+++ b/mus2midi.c
@@ -147,7 +147,7 @@ BYTE *mus2midi(BYTE *data, int *length)
 {
     HDR_MUS     *hdrMus = (HDR_MUS *)data;
     HDR_MID     hdrMid;
-    BYTE        *midTrkLen;
+    int         midTrkLenOffset;
     int         trackLen;
     int         i;
 
@@ -170,7 +170,7 @@ BYTE *mus2midi(BYTE *data, int *length)
     midData = realloc(midData, midSize + 8);
     memcpy(midData + midSize, magicTrk, 4);
     midSize += 4;
-    midTrkLen = midData + midSize;
+    midTrkLenOffset = midSize;
     midSize += 4;
 
     trackLen = 0;
@@ -196,7 +196,7 @@ BYTE *mus2midi(BYTE *data, int *length)
     midSize += 3;
 
     trackLen = __builtin_bswap32(midSize - sizeof(HDR_MID) - 8);
-    memcpy(midTrkLen, &trackLen, 4);
+    memcpy(midData + midTrkLenOffset, &trackLen, 4);
 
     *length = midSize;
 


### PR DESCRIPTION
The pointer midTrkLen to malloc:ed data was reused after the data had beed realloc:ed. This sometimes results in the wrong memory location being written and the track length header field to be incorrect.

The track length in a MIDI file is redundant since each track is in any case concluded with an End-of-track event. Software can therefore ignore the track length header field. But Windows Media Player will refuse to play MIDI files where the track length header does not match the actual length.